### PR TITLE
Tidy up the codes

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,17 +13,21 @@ android {
         targetSdk = 34
         versionCode = 2
         versionName = "0.0.2-alpha"
-        multiDexEnabled = true
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {
             useSupportLibrary = true
         }
+
+        ndk {
+            //abiFilters += "armeabi-v7a", "arm64-v8a", "x86", "x86_64"
+            abiFilters += "arm64-v8a"
+        }
     }
 
     buildTypes {
         release {
-            isMinifyEnabled = false
+            isMinifyEnabled = true
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
@@ -37,9 +41,6 @@ android {
     kotlinOptions {
         jvmTarget = "1.8"
     }
-    buildFeatures {
-        compose = true
-    }
     composeOptions {
         kotlinCompilerExtensionVersion = "1.5.1"
     }
@@ -51,22 +52,14 @@ android {
         jniLibs {
             pickFirsts += "lib/*/libc++_shared.so"
         }
-        resources {
-            pickFirsts += "androidsupportmultidexversion.txt"
-        }
     }
 }
 
 dependencies {
-    implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.activity.fragment)
+    implementation("androidx.core:core-ktx:1.13.1")
 
     implementation(libs.androidx.window)
-    implementation(platform(libs.androidx.compose.bom))
-    implementation(libs.androidx.multidex)
     implementation(libs.bundles.onyx)
     implementation(libs.hiddenapibypass)
-
-    debugImplementation(libs.androidx.ui.tooling)
-    debugImplementation(libs.androidx.ui.test.manifest)
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,7 +21,7 @@ android {
 
         ndk {
             //abiFilters += "armeabi-v7a", "arm64-v8a", "x86", "x86_64"
-            abiFilters += "arm64-v8a"
+            abiFilters += setOf("armeabi-v7a", "arm64-v8a")
         }
     }
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -57,7 +57,7 @@ android {
 
 dependencies {
     implementation(libs.androidx.activity.fragment)
-    implementation("androidx.core:core-ktx:1.13.1")
+    implementation(libs.androidx.core.ktx)
 
     implementation(libs.androidx.window)
     implementation(libs.bundles.onyx)

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -19,3 +19,8 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+-dontwarn org.joda.convert.**
+-dontwarn org.slf4j.impl.**
+-keep class org.joda.time.** { *; }
+-keep class org.slf4j.** { *; }

--- a/app/src/main/kotlin/com/sergeylappo/booxrapiddraw/BooxRapidDraw.kt
+++ b/app/src/main/kotlin/com/sergeylappo/booxrapiddraw/BooxRapidDraw.kt
@@ -1,17 +1,11 @@
 package com.sergeylappo.booxrapiddraw
 
-import android.content.Context
+import android.app.Application
 import android.os.Build
-import androidx.multidex.MultiDex
-import androidx.multidex.MultiDexApplication
 import com.onyx.android.sdk.rx.RxManager
 import org.lsposed.hiddenapibypass.HiddenApiBypass
 
-class BooxRapidDraw : MultiDexApplication() {
-    override fun attachBaseContext(base: Context) {
-        super.attachBaseContext(base)
-        MultiDex.install(this@BooxRapidDraw)
-    }
+class BooxRapidDraw : Application() {
 
     override fun onCreate() {
         super.onCreate()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,11 +1,8 @@
 [versions]
-activityCompose = "1.9.2"
 agp = "8.5.2"
-composeBom = "2024.09.03"
 fragment = "1.8.4"
 hiddenapibypass = "4.3"
 kotlin = "1.9.0"
-multidex = "2.0.1"
 onyxDevice = "1.2.30"
 onyxPen = "1.4.11"
 window = "1.3.0"
@@ -13,12 +10,7 @@ window = "1.3.0"
 [libraries]
 hiddenapibypass = { module = "org.lsposed.hiddenapibypass:hiddenapibypass", version.ref = "hiddenapibypass" }
 androidx-activity-fragment = { group = "androidx.fragment", name = "fragment-ktx", version.ref = "fragment" }
-androidx-multidex = { module = "androidx.multidex:multidex", version.ref = "multidex" }
-androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
-androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
 androidx-window = { group = "androidx.window", name = "window", version.ref = "window" }
-androidx-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
-androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 
 onyx-device = { group = "com.onyx.android.sdk", name = "onyxsdk-device", version.ref = "onyxDevice" }
 onyx-pen = { group = "com.onyx.android.sdk", name = "onyxsdk-pen", version.ref = "onyxPen" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
 agp = "8.5.2"
+coreKtx = "1.13.1"
 fragment = "1.8.4"
 hiddenapibypass = "4.3"
 kotlin = "1.9.0"
@@ -8,6 +9,7 @@ onyxPen = "1.4.11"
 window = "1.3.0"
 
 [libraries]
+androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "coreKtx" }
 hiddenapibypass = { module = "org.lsposed.hiddenapibypass:hiddenapibypass", version.ref = "hiddenapibypass" }
 androidx-activity-fragment = { group = "androidx.fragment", name = "fragment-ktx", version.ref = "fragment" }
 androidx-window = { group = "androidx.window", name = "window", version.ref = "window" }


### PR DESCRIPTION
The binary size is reduced from 29MB to 17MB


* Remove un-necessary parts
  * Compose dependency
  * MultiDex
* Enable proguard
* only select arm64-v8 native libraries