### PR TITLE
Move Exit behvaior to notification and BOOX's floating button

### DIFF
--- a/app/src/main/kotlin/com/sergeylappo/booxrapiddraw/OverlayShowingService.kt
+++ b/app/src/main/kotlin/com/sergeylappo/booxrapiddraw/OverlayShowingService.kt
@@ -19,7 +19,6 @@ import android.view.SurfaceView
 import android.view.View
 import android.view.View.OnLayoutChangeListener
 import android.view.WindowManager
-import android.widget.Button
 import android.widget.Toast
 import androidx.core.app.NotificationCompat
 import androidx.core.app.ServiceCompat
@@ -70,7 +69,6 @@ class OverlayShowingService : Service() {
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         if (intent?.action == "STOP") {
             stopSelf()
-            exitProcess(0)
         }
 
         val prefs = getSharedPreferences(PREFS_NAME, MODE_PRIVATE)

--- a/app/src/main/kotlin/com/sergeylappo/booxrapiddraw/OverlayShowingService.kt
+++ b/app/src/main/kotlin/com/sergeylappo/booxrapiddraw/OverlayShowingService.kt
@@ -13,7 +13,6 @@ import android.graphics.Paint
 import android.graphics.PixelFormat
 import android.graphics.Rect
 import android.graphics.RectF
-import android.view.GestureDetector
 import android.view.Gravity
 import android.view.MotionEvent
 import android.view.SurfaceView
@@ -21,6 +20,7 @@ import android.view.View
 import android.view.View.OnLayoutChangeListener
 import android.view.WindowManager
 import android.widget.Button
+import android.widget.Toast
 import androidx.core.app.NotificationCompat
 import androidx.core.app.ServiceCompat
 import com.onyx.android.sdk.api.device.epd.EpdController
@@ -45,7 +45,6 @@ class OverlayShowingService : Service() {
     private val paint = Paint()
 
     private lateinit var touchHelper: TouchHelper
-    private lateinit var overlayButton: Button
     private lateinit var wm: WindowManager
     private lateinit var overlayPaintingView: SurfaceView
 
@@ -78,6 +77,7 @@ class OverlayShowingService : Service() {
         val isRunning = prefs.getBoolean(KEY_IS_RUNNING, false)
 
         if (isRunning) {
+            Toast.makeText(this, "Terminating Rapid Draw Service...", Toast.LENGTH_SHORT).show()
             stopSelf()
             return START_NOT_STICKY // Prevents service from being recreated
         }
@@ -85,6 +85,7 @@ class OverlayShowingService : Service() {
         // Set the flag to indicate that the service is now running
         prefs.edit().putBoolean(KEY_IS_RUNNING, true).apply()
 
+        Toast.makeText(this, "Starting Rapid Draw Service", Toast.LENGTH_SHORT).show()
         return START_STICKY // Service will be recreated if killed
     }
 

--- a/app/src/main/kotlin/com/sergeylappo/booxrapiddraw/OverlayShowingService.kt
+++ b/app/src/main/kotlin/com/sergeylappo/booxrapiddraw/OverlayShowingService.kt
@@ -105,7 +105,7 @@ class OverlayShowingService : Service() {
             this,
             0,
             Intent(this, OverlayShowingService::class.java).apply { action = "STOP" },
-            PendingIntent.FLAG_UPDATE_CURRENT
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
         )
 
         val notification = NotificationCompat.Builder(this, CHANNEL_ID)

--- a/app/src/main/kotlin/com/sergeylappo/booxrapiddraw/PreferenceKey.kt
+++ b/app/src/main/kotlin/com/sergeylappo/booxrapiddraw/PreferenceKey.kt
@@ -1,0 +1,7 @@
+package com.sergeylappo.booxrapiddraw
+
+const val PREFS_NAME = "MyServicePrefs"
+
+enum class PreferenceKey(val key: String) {
+    IS_RUNNING("IS_RUNNING")
+}


### PR DESCRIPTION
Two ways to leave Rapid Draw Service:
1. click on notification item
2. click on the BOOX floating button, with a RapidDraw app on it: when service is not launched yet, it will enable it; when service is already there, it will stop the service.

UI fix:
use app icon as notification icon