### PR TITLE
Added FOREGROUND_SERVICE permissions required for app to work on android 14+

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
 
     <application
         android:name="com.sergeylappo.booxrapiddraw.BooxRapidDraw"


### PR DESCRIPTION

According to android [docs](https://developer.android.com/about/versions/14/changes/fgs-types-required), since android 14, if using `android:foregroundServiceType` attribute, app must declare foreground service type.

After this change, app does not crash and works great on Note Air 5c

